### PR TITLE
Added poll endpoint to return data to original tf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 # binary build
 server
 bin
+
+# ides
+.vscode

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/galleybytes/terraform-operator-api/internal/qworker"
 	"github.com/galleybytes/terraform-operator-api/pkg/api"
 	"github.com/galleybytes/terraform-operator-api/pkg/common/db"
 	"github.com/gammazero/deque"
 	tfv1alpha2 "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha2"
+	tfo "github.com/isaaguilar/terraform-operator/pkg/client/clientset/versioned"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func main() {
@@ -17,12 +24,22 @@ func main() {
 	port := viper.Get("PORT").(string)
 	dbUrl := viper.Get("DB_URL").(string)
 
+	clientset := kubernetes.NewForConfigOrDie(NewConfigOrDie(os.Getenv("KUBECONFIG")))
+	tfoclientset := tfo.NewForConfigOrDie(NewConfigOrDie(os.Getenv("KUBECONFIG")))
 	database := db.Init(dbUrl)
 	queue := deque.Deque[tfv1alpha2.Terraform]{}
 
 	qworker.BackgroundWorker(&queue)
 
-	apiHandler := api.NewAPIHandler(database, &queue)
+	apiHandler := api.NewAPIHandler(database, &queue, clientset, tfoclientset)
 	apiHandler.RegisterRoutes()
 	apiHandler.Server.Run(port)
+}
+
+func NewConfigOrDie(kubeconfigPath string) *rest.Config {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		log.Fatal("Failed to get config for clientset")
+	}
+	return config
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gin-gonic/gin v1.8.1
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/isaaguilar/terraform-operator v0.9.0-beta3
-	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
 	github.com/spf13/viper v1.12.0
 	gorm.io/driver/postgres v1.3.9
 	gorm.io/gorm v1.23.8
@@ -27,6 +26,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,7 +151,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -326,6 +325,7 @@ github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -502,8 +502,6 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
-github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24 h1:uYuGXJBAi1umT+ZS4oQJUgKtfXCAYTR+n9zw1ViT0vA=
-github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -555,6 +553,7 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=

--- a/k8s/clusterrole.yaml
+++ b/k8s/clusterrole.yaml
@@ -9,3 +9,11 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+  - read

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -4,20 +4,26 @@ import (
 	"github.com/gammazero/deque"
 	"github.com/gin-gonic/gin"
 	tfv1alpha2 "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha2"
+	tfo "github.com/isaaguilar/terraform-operator/pkg/client/clientset/versioned"
 	"gorm.io/gorm"
+	"k8s.io/client-go/kubernetes"
 )
 
 type APIHandler struct {
-	Server *gin.Engine
-	DB     *gorm.DB
-	Queue  *deque.Deque[tfv1alpha2.Terraform]
+	Server       *gin.Engine
+	DB           *gorm.DB
+	Queue        *deque.Deque[tfv1alpha2.Terraform]
+	clientset    kubernetes.Interface
+	tfoclientset tfo.Interface
 }
 
-func NewAPIHandler(db *gorm.DB, queue *deque.Deque[tfv1alpha2.Terraform]) *APIHandler {
+func NewAPIHandler(db *gorm.DB, queue *deque.Deque[tfv1alpha2.Terraform], clientset kubernetes.Interface, tfoclientset tfo.Interface) *APIHandler {
 	return &APIHandler{
-		Server: gin.Default(),
-		DB:     db,
-		Queue:  queue,
+		Server:       gin.Default(),
+		DB:           db,
+		Queue:        queue,
+		clientset:    clientset,
+		tfoclientset: tfoclientset,
 	}
 }
 
@@ -28,22 +34,24 @@ func (h APIHandler) RegisterRoutes() {
 	routes := h.Server.Group("/api/v1/")
 	routes.Use(validateJwt)
 	routes.GET("/", h.Index)
-	// Resource from Add/Update/Delete event
-	routes.POST("/cluster/:cluster_id/event", h.ResourceEvent)
-	routes.PUT("/cluster/:cluster_id/event", h.ResourceEvent)
-	routes.DELETE("/cluster/:cluster_id/event/:tfo_resource_uuid", h.ResourceEvent)
-	// Clusters
-	routes.POST("/cluster", h.AddCluster)
+
+	cluster := routes.Group("/cluster")
+	cluster.POST("/", h.AddCluster) // Resource from Add/Update/Delete event
+	cluster.GET("/:cluster_id", h.GetCluster)
+	cluster.POST("/:cluster_name/event", h.ResourceEvent) // routes.GET("/cluster-name/:cluster_name", h.GetCluster) // to be removed
+	cluster.PUT("/:cluster_name/event", h.ResourceEvent)
+	cluster.GET("/:cluster_id/resources", h.GetClustersResources) // List Resources
+	cluster.DELETE("/:cluster_name/event/:tfo_resource_uuid", h.ResourceEvent)
+
+	// List Clusters
 	routes.GET("/clusters", h.ListClusters)
-	routes.GET("/cluster/:cluster_id", h.GetCluster)
-	routes.GET("/cluster-name/:cluster_name", h.GetCluster)
-	// Resources
-	routes.GET("/cluster/:cluster_id/resources", h.GetClustersResources)
 	routes.GET("/resource/:tfo_resource_uuid", h.GetResourceByUUID)
 	// List Generations
 	routes.GET("/resource/:tfo_resource_uuid/generations", h.GetDistinctGeneration)
 	// ReourceSpec
 	routes.GET("/resource/:tfo_resource_uuid/resource-spec/generation/:generation", h.GetResourceSpec)
+	// Poll for resource objects in the cluster
+	routes.GET("/resource/:tfo_resource_uuid/poll", h.ResourcePoll)
 	// Logs
 	routes.POST("/logs", h.AddTFOTaskLogs) // requires access to fs of logs
 	routes.GET("/resource/:tfo_resource_uuid/logs", h.GetClustersResourcesLogs)

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -144,7 +144,6 @@ func (h APIHandler) ResourcePoll(c *gin.Context) {
 		outputsSecretName = fmt.Sprintf("%-v%s", tf.Status.PodNamePrefix, fmt.Sprint(tf.Generation))
 	}
 	if tf.Spec.OutputsSecret != "" {
-		// https://github.com/isaaguilar/terraform-operator/blob/master/pkg/controllers/terraform_controller.go#L428
 		outputsSecretName = tf.Spec.OutputsSecret
 	}
 	if outputsSecretName == "" {
@@ -156,6 +155,10 @@ func (h APIHandler) ResourcePoll(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
 		return
+	}
+	if originalOutputsSecretName, found := tf.Annotations["tfo.galleybytes.com/outputsSecret"]; found {
+		// When this annotation is found in the tf-resource, rename the secret before returning it
+		secret.Name = originalOutputsSecretName
 	}
 	gvks, _, err := scheme.Scheme.ObjectKinds(secret)
 	if err != nil {

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,10 @@ import (
 	"github.com/gin-gonic/gin"
 	tfv1alpha2 "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha2"
 	"gorm.io/gorm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 type resource struct {
@@ -98,6 +103,77 @@ func (h APIHandler) AddCluster(c *gin.Context) {
 	c.JSON(http.StatusOK, response(http.StatusOK, "", []models.Cluster{cluster}))
 }
 
+func (h APIHandler) getClusterID(clusterName string) uint {
+	// TODO Use a temporary cache to store clusterName to remove a db lookup
+	var clusters []models.Cluster
+	if result := h.DB.Where("name = ?", clusterName).First(&clusters); result.Error != nil {
+		return 0
+	}
+	return clusters[0].ID
+}
+
+// ResourcePoll is a short poll that checks and returns resources created from the tf resource's workflow
+//
+// TODO Currently only secrets are expected to be created by the workflow. Resources created outside of the
+//
+//	normal workflow are ignored. Is it possible to extend get a more extensive list of resources to return?
+//	One issue with this is that TFO does not have a method to track those resources.
+func (h APIHandler) ResourcePoll(c *gin.Context) {
+	resourceUUID := c.Param("tfo_resource_uuid")
+
+	// Before checking for resources to return, check that the current generation has completed
+	tf, err := h.tfoclientset.TfV1alpha2().Terraforms("default").Get(c, resourceUUID, metav1.GetOptions{})
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
+		return
+	}
+	if tf.Status.Stage.Generation != tf.Generation || tf.Status.Stage.Reason != "COMPLETED_APPLY" {
+		c.JSON(http.StatusOK, response(http.StatusOK, fmt.Sprintf("The '%s' workflow has not completed", tf.Name), nil))
+		return
+	}
+
+	// Check if this contains known resources to return
+	outputsSecretName := ""
+	if tf.Spec.WriteOutputsToStatus {
+		// https://github.com/isaaguilar/terraform-operator/blob/master/pkg/controllers/terraform_controller.go#L278
+		outputsSecretName = fmt.Sprintf("%-v%s", tf.Status.PodNamePrefix, fmt.Sprint(tf.Generation))
+	}
+	if tf.Spec.OutputsSecret != "" {
+		// https://github.com/isaaguilar/terraform-operator/blob/master/pkg/controllers/terraform_controller.go#L428
+		outputsSecretName = tf.Spec.OutputsSecret
+	}
+	if outputsSecretName == "" {
+		c.JSON(http.StatusOK, response(http.StatusOK, fmt.Sprintf("The '%s' workflow does not create secrets", tf.Name), nil))
+	}
+
+	secretClient := h.clientset.CoreV1().Secrets("default")
+	secret, err := secretClient.Get(c, outputsSecretName, metav1.GetOptions{})
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
+		return
+	}
+	gvks, _, err := scheme.Scheme.ObjectKinds(secret)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
+		return
+	}
+	if len(gvks) == 0 {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, "Resource is does not have a registered version", nil))
+		return
+	}
+	secret.SetGroupVersionKind(gvks[0])
+
+	buf := bytes.NewBuffer([]byte{})
+	serializer.
+		NewSerializer(serializer.DefaultMetaFactory, runtime.NewScheme(), runtime.NewScheme(), true).
+		Encode(secret, buf)
+
+	resources := []string{}
+	resources = append(resources, buf.String())
+
+	c.JSON(http.StatusOK, response(http.StatusOK, "", resources))
+}
+
 func (h APIHandler) ResourceEvent(c *gin.Context) {
 	if c.Request.Method == http.MethodPost {
 		err := h.addResource(c)
@@ -130,18 +206,13 @@ func (h APIHandler) ResourceEvent(c *gin.Context) {
 }
 
 func (h APIHandler) addResource(c *gin.Context) error {
-	clusterID := c.Param("cluster_id")
-	if clusterID == "" || clusterID == "0" {
-		return errors.New(":cluster_id: url parameter cannot be empty or 0")
+	clusterName := c.Param("cluster_name")
+	clusterID := h.getClusterID(clusterName)
+	if clusterID == 0 {
+		return fmt.Errorf("cluster_name '%s' not found", clusterName)
 	}
-	clusterIDInt, err := strconv.Atoi(clusterID)
-	if err != nil {
-		return errors.New(":cluster_id: url parameter must be a valid integer")
-	}
-	clusterIDUint := uint(clusterIDInt)
-
 	jsonData := resource{}
-	err = c.BindJSON(&jsonData)
+	err := c.BindJSON(&jsonData)
 	if err != nil {
 		log.Println("Unable to parse JSON from request data")
 		return errors.New("Unable to parse JSON from request data: " + err.Error())
@@ -153,14 +224,14 @@ func (h APIHandler) addResource(c *gin.Context) error {
 		return err
 	}
 
-	tfoResource, tfoResourceSpec, err := jsonData.Parse(clusterIDUint)
+	tfoResource, tfoResourceSpec, err := jsonData.Parse(clusterID)
 	if err != nil {
 		return err
 	}
 
 	cluster := &models.Cluster{
 		Model: gorm.Model{
-			ID: clusterIDUint,
+			ID: clusterID,
 		},
 	}
 	result := h.DB.First(cluster)
@@ -197,18 +268,14 @@ func (h APIHandler) addResource(c *gin.Context) error {
 }
 
 func (h APIHandler) updateResource(c *gin.Context) error {
-	clusterID := c.Param("cluster_id")
-	if clusterID == "" || clusterID == "0" {
-		return errors.New(":cluster_id: url parameter cannot be empty or 0")
+	clusterName := c.Param("cluster_name")
+	clusterID := h.getClusterID(clusterName)
+	if clusterID == 0 {
+		return fmt.Errorf("cluster_name '%s' not found", clusterName)
 	}
-	clusterIDInt, err := strconv.Atoi(clusterID)
-	if err != nil {
-		return errors.New(":cluster_id: url parameter must be a valid integer")
-	}
-	clusterIDUint := uint(clusterIDInt)
 
 	jsonData := resource{}
-	err = c.BindJSON(&jsonData)
+	err := c.BindJSON(&jsonData)
 	if err != nil {
 		log.Println("Unable to parse JSON from request data")
 		return errors.New("Unable to parse JSON from request data: " + err.Error())
@@ -220,14 +287,14 @@ func (h APIHandler) updateResource(c *gin.Context) error {
 		return err
 	}
 
-	tfoResource, tfoResourceSpec, err := jsonData.Parse(clusterIDUint)
+	tfoResource, tfoResourceSpec, err := jsonData.Parse(clusterID)
 	if err != nil {
 		return err
 	}
 
 	cluster := &models.Cluster{
 		Model: gorm.Model{
-			ID: clusterIDUint,
+			ID: clusterID,
 		},
 	}
 	result := h.DB.First(cluster)
@@ -283,20 +350,6 @@ func (h APIHandler) appendClusterNameLabel(tf *tfv1alpha2.Terraform, clusterName
 		tf.Labels = map[string]string{}
 	}
 	tf.Labels["tfo-api.galleybytes.com/cluster-name"] = clusterName
-}
-
-func equalOrGreater(s1, s2 string) bool {
-	i1, err := strconv.Atoi(s1)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	i2, err := strconv.Atoi(s2)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	return i1 >= i2
 }
 
 func compare(s1, op, s2 string) bool {

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -128,7 +128,12 @@ func (h APIHandler) ResourcePoll(c *gin.Context) {
 		return
 	}
 	if tf.Status.Stage.Generation != tf.Generation || tf.Status.Stage.Reason != "COMPLETED_APPLY" {
-		c.JSON(http.StatusOK, response(http.StatusOK, fmt.Sprintf("The '%s' workflow has not completed", tf.Name), nil))
+		c.JSON(http.StatusOK, response(http.StatusOK, fmt.Sprintf("The '%s' workflow has not completed.", tf.Name), nil))
+		return
+	}
+	if h.Queue.Len() > 0 {
+		// Wait for all queue to complete before opening up for polling
+		c.JSON(http.StatusOK, response(http.StatusOK, "Waiting for API to complete queue.", nil))
 		return
 	}
 


### PR DESCRIPTION
**Features**

The new poll allows using the API to search for generated resources (ie secrets) that are created as part of the tf workflow. Secrets that are created as part of a workflow must be returned to the original cluster. The new poll mechanism returns the secret to the caller.

**Breaking Changes**

- The `:cluster_id:` in the cluster api has changed to the `cluster_name` instead. The name will be used to lookup the id.