### PR TITLE
adding LastTaskLog api feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ucarion/saml v0.1.2
 	github.com/ugorji/go/codec v1.2.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,8 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
@@ -861,6 +861,7 @@ gorm.io/driver/postgres v1.3.9/go.mod h1:qw/FeqjxmYqW5dBcYNBsnhQULIApQdk7YuuDPkt
 gorm.io/gorm v1.23.7/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.23.8 h1:h8sGJ+biDgBA1AD1Ha9gFCx7h8npU7AsLdlkX0n2TpE=
 gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -87,6 +87,7 @@ func (h APIHandler) RegisterRoutes() {
 	cluster.GET("/:cluster_name/debug/:namespace/:name", h.Debugger) // Alias
 	cluster.GET("/:cluster_name/resource/:namespace/:name/status", h.ResourceStatusCheck)
 	cluster.GET("/:cluster_name/status/:namespace/:name", h.ResourceStatusCheck) // Alias
+	cluster.GET("/:cluster_name/resource/:namespace/:name/last-task-log", h.LastTaskLog)
 
 	// DEPRECATED usage of clusterid is being removed. todo ensure galleybytes projects aren't using this
 	clusterid := routes.Group("/cluster-id")

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -364,13 +364,13 @@ func (h APIHandler) LastTaskLog(c *gin.Context) {
 	labelSelector := "terraforms.tf.galleybytes.com/resourceName=" + resourceName // change this to your label selector
 	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
-		c.JSON(http.StatusBadRequest, response(http.StatusBadRequest, err.Error(), nil))
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
 		return
 	}
 
 	// check if pods were found with matching labels
 	if len(pods.Items) == 0 {
-		c.JSON(http.StatusUnprocessableEntity, response(http.StatusNotFound, fmt.Sprintf("terraform pods not found on cluster '%s' for tf resource '%s'/%s'", clusterName, namespace, resourceName), nil))
+		c.JSON(http.StatusNotFound, response(http.StatusNotFound, fmt.Sprintf("terraform pods not found on cluster '%s' for tf resource '%s/%s'", clusterName, namespace, resourceName), nil))
 		return
 	}
 
@@ -389,7 +389,7 @@ func (h APIHandler) LastTaskLog(c *gin.Context) {
 
 	pod, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), newestPod, metav1.GetOptions{})
 	if err != nil {
-		c.JSON(http.StatusNotFound, response(http.StatusNotFound, err.Error(), nil))
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
 		return
 	}
 
@@ -406,7 +406,7 @@ func (h APIHandler) LastTaskLog(c *gin.Context) {
 	// get the logs of the newest pod
 	logs, err := clientset.CoreV1().Pods(namespace).GetLogs(newestPod, &corev1.PodLogOptions{}).DoRaw(context.Background())
 	if err != nil {
-		c.JSON(http.StatusNotFound, response(http.StatusNotFound, err.Error(), nil))
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
 		return
 	}
 

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -360,6 +360,13 @@ func (h APIHandler) LastTaskLog(c *gin.Context) {
 
 	clientset := kubernetes.NewForConfigOrDie(config)
 
+	// check if namespace exists before querying for pods by label
+	_, err = clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
+		return
+	}
+
 	// get the pods with a certain label in the default namespace
 	labelSelector := "terraforms.tf.galleybytes.com/resourceName=" + resourceName // change this to your label selector
 	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
+	"time"
 
 	"github.com/galleybytes/terraform-operator-api/pkg/common/models"
 	"github.com/galleybytes/terraform-operator-api/pkg/util"
@@ -42,6 +44,14 @@ type resource struct {
 	// TFOResourceSpec models.TFOResourceSpec `json:"tfo_resource_spec"`
 	// TFOResource     models.TFOResource     `json:"tfo_resource"`
 }
+
+type PodInfo struct {
+	Name      string
+	CreatedAt time.Time
+}
+
+// ByCreatedAt implements sort.Interface for []PodInfo based on the CreatedAt field
+type ByCreatedAt []PodInfo
 
 func (r resource) validate() error {
 
@@ -319,6 +329,99 @@ func (h APIHandler) ResourceStatusCheck(c *gin.Context) {
 			DidComplete:  !IsWorkflowRunning(resource.Status),
 			CurrentState: string(resource.Status.Stage.State),
 			CurrentTask:  resource.Status.Stage.TaskType.String(),
+		},
+	}
+
+	c.JSON(http.StatusOK, response(http.StatusOK, "", responseJSONData))
+
+}
+
+func (a ByCreatedAt) Len() int           { return len(a) }
+func (a ByCreatedAt) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByCreatedAt) Less(i, j int) bool { return a[i].CreatedAt.Before(a[j].CreatedAt) }
+
+func (h APIHandler) LastTaskLog(c *gin.Context) {
+	clusterName := c.Param("cluster_name")
+	clusterID := h.getClusterID(clusterName)
+
+	if clusterID == 0 {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, fmt.Sprintf("cluster_name '%s' not found", clusterName), nil))
+		return
+	}
+
+	resourceName := c.Param("name")
+	namespace := c.Param("namespace")
+
+	config, err := getVclusterConfig(h.clientset, "internal", clusterName)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
+		return
+	}
+
+	clientset := kubernetes.NewForConfigOrDie(config)
+
+	// get the pods with a certain label in the default namespace
+	labelSelector := "terraforms.tf.galleybytes.com/resourceName=" + resourceName // change this to your label selector
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// check if pods were found with matching labels
+	if len(pods.Items) == 0 {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusNotFound, fmt.Sprintf("terraform pods not found on cluster '%s' for tf resource '%s'/%s'", clusterName, namespace, resourceName), nil))
+	}
+
+	// create a slice of PodInfo from the pods
+	podInfos := make([]PodInfo, 0, len(pods.Items))
+
+	for _, pod := range pods.Items {
+		podInfos = append(podInfos, PodInfo{Name: pod.Name, CreatedAt: pod.CreationTimestamp.Time})
+	}
+
+	// sort the podInfos by creation timestamp in ascending order
+	sort.Sort(ByCreatedAt(podInfos))
+
+	// get the name of the newest pod
+	newestPod := podInfos[len(podInfos)-1].Name
+
+	pod, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), newestPod, metav1.GetOptions{})
+	if err != nil {
+		log.Panic()
+	}
+
+	currentTask := ""
+	// find the environment variable
+	for _, container := range pod.Spec.Containers {
+		for _, envVar := range container.Env {
+			if envVar.Name == "TFO_TASK" {
+				currentTask = envVar.Value
+			}
+		}
+	}
+
+	// get the logs of the newest pod
+	logs, err := clientset.CoreV1().Pods(namespace).GetLogs(newestPod, &corev1.PodLogOptions{}).DoRaw(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ansiColorRegex := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+	cleanString := ansiColorRegex.ReplaceAllString(string(logs), "")
+
+	responseJSONData := []struct {
+		ClusterName string `json:"cluster_name"`
+		Namespace   string `json:"namespace"`
+		TFOResource string `json:"tfo_resource"`
+		CurrentTask string `json:"current_task"`
+		LastTaskLog string `json:"last_task_log"`
+	}{
+		{
+			ClusterName: string(clusterName),
+			Namespace:   string(namespace),
+			TFOResource: string(resourceName),
+			CurrentTask: string(currentTask),
+			LastTaskLog: string(cleanString),
 		},
 	}
 


### PR DESCRIPTION
**Changes:**
- added api call to get last tfo task log output. 
- enabled tforc to work perform operations on same cluster as tfo hub 

Were using StatusUnprocessableEntity for most errors so I stuck with that error response.

Listing pods with labels  (line 372) doesn't return an error if the. namespace exists.I added a namespace check before to return a precise error but it would also be picked up by the pod length check on (379) .  I can remove it if you'd like but I like the idea of pre-checking