### PR TITLE
add TFO_ORIGIN envs used for logging

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -65,17 +65,11 @@ func NewAPIHandler(db *gorm.DB, queue *deque.Deque[tfv1beta1.Terraform], clients
 }
 
 func (h APIHandler) RegisterRoutes() {
-	auth := h.Server.Group("/")
-	auth.POST("/login", h.login)
-	auth.GET("/connect", h.defaultConnectMethod) // Determine preferred auth method
-	auth.GET("/sso", h.ssoRedirecter)
-	auth.POST("/sso/saml", h.samlConnecter)
-
-	empty := h.Server.Group("/")
-	empty.GET("/placeholder", func(c *gin.Context) {
+	preauth := h.Server.Group("/")
+	preauth.GET("/noauthtest", func(c *gin.Context) {
 		c.JSON(200, response(200, "", []string{"Please come again!"}))
 	})
-	empty.POST("/placeholder", func(c *gin.Context) {
+	preauth.POST("/noauthtest", func(c *gin.Context) {
 		var data any
 		err := c.BindJSON(&data)
 		if err != nil {
@@ -85,11 +79,16 @@ func (h APIHandler) RegisterRoutes() {
 		c.JSON(200, response(200, "", []any{data}))
 	})
 
-	routes := h.Server.Group("/api/v1/")
-	routes.Use(validateJwt)
-	routes.GET("/", h.Index)
+	preauth.POST("/login", h.login)
+	preauth.GET("/connect", h.defaultConnectMethod) // Determine preferred auth method
+	preauth.GET("/sso", h.ssoRedirecter)
+	preauth.POST("/sso/saml", h.samlConnecter)
 
-	cluster := routes.Group("/cluster")
+	authenticatedAPIV1 := h.Server.Group("/api/v1/")
+	authenticatedAPIV1.Use(validateJwt)
+	authenticatedAPIV1.GET("/", h.Index)
+
+	cluster := authenticatedAPIV1.Group("/cluster")
 	cluster.POST("/", h.AddCluster) // Resource from Add/Update/Delete event
 	cluster.GET("/:cluster_name/health", h.VClusterHealth)
 	cluster.GET("/:cluster_name/tfohealth", h.VClusterTFOHealth)
@@ -104,33 +103,35 @@ func (h APIHandler) RegisterRoutes() {
 	cluster.GET("/:cluster_name/status/:namespace/:name", h.ResourceStatusCheck) // Alias
 
 	// DEPRECATED usage of clusterid is being removed. todo ensure galleybytes projects aren't using this
-	clusterid := routes.Group("/cluster-id")
+	clusterid := authenticatedAPIV1.Group("/cluster-id")
 	clusterid.GET("/:cluster_id", h.GetCluster)
 	clusterid.GET("/:cluster_id/resources", h.GetClustersResources) // List Resources
 
 	// List Clusters
-	routes.GET("/clusters", h.ListClusters)
-	routes.GET("/resource/:tfo_resource_uuid", h.GetResourceByUUID)
+	authenticatedAPIV1.GET("/clusters", h.ListClusters)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid", h.GetResourceByUUID)
 	// List Generations
-	routes.GET("/resource/:tfo_resource_uuid/generations", h.GetDistinctGeneration)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/generations", h.GetDistinctGeneration)
 	// ReourceSpec
-	routes.GET("/resource/:tfo_resource_uuid/resource-spec/generation/:generation", h.GetResourceSpec)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/resource-spec/generation/:generation", h.GetResourceSpec)
 
-	routes.GET("/resource/:tfo_resource_uuid/logs", h.GetClustersResourcesLogs)
-	routes.GET("/resource/:tfo_resource_uuid/logs/generation/:generation", h.GetClustersResourcesLogs)
-	routes.GET("/resource/:tfo_resource_uuid/logs/generation/:generation/task/:task_type", h.GetClustersResourcesLogs)
-	routes.GET("/resource/:tfo_resource_uuid/logs/generation/:generation/task/:task_type/rerun/:rerun", h.GetClustersResourcesLogs)
-	routes.GET("/task/:task_pod_uuid/logs", h.GetTFOTaskLogsViaTask)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/logs", h.GetClustersResourcesLogs)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/logs/generation/:generation", h.GetClustersResourcesLogs)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/logs/generation/:generation/task/:task_type", h.GetClustersResourcesLogs)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/logs/generation/:generation/task/:task_type/rerun/:rerun", h.GetClustersResourcesLogs)
+	authenticatedAPIV1.GET("/task/:task_pod_uuid/logs", h.GetTFOTaskLogsViaTask)
+	authenticatedAPIV1.GET("/task/:task_pod_uuid", h.GetTaskPod) // TODO Should getting a task out of band (ie not with cluster info) be allowed?
 
-	// Tasks
-	routes.POST("/task", h.AddTaskPod)
-	routes.GET("/task/:task_pod_uuid", h.GetTaskPod) // TODO Should getting a task out of band (ie not with cluster info) be allowed?
+	// Tasks via task JWT
+	authenticatedTask := h.Server.Group("/api/v1/task")
+	authenticatedTask.Use(validateTaskJWT)
+	authenticatedTask.POST("/", h.AddTaskPod)
 
 	// Approval
-	routes.GET("/resource/:tfo_resource_uuid/approval-status", h.GetApprovalStatus)
-	routes.GET("/task/:task_pod_uuid/approval-status", h.GetApprovalStatusViaTaskPodUUID)
-	routes.POST("/approval/:task_pod_uuid", h.UpdateApproval)
-	routes.GET("/approvals", h.AllApprovals)
+	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/approval-status", h.GetApprovalStatus)
+	authenticatedAPIV1.GET("/task/:task_pod_uuid/approval-status", h.GetApprovalStatusViaTaskPodUUID)
+	authenticatedAPIV1.POST("/approval/:task_pod_uuid", h.UpdateApproval)
+	authenticatedAPIV1.GET("/approvals", h.AllApprovals)
 
 	// Websockets will be prefixed with /ws
 	sockets := h.Server.Group("/ws/")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/x509"
 	"fmt"
+	"net/http"
 
 	tfv1beta1 "github.com/galleybytes/terraform-operator/pkg/apis/tf/v1beta1"
 	"github.com/gammazero/deque"
@@ -70,6 +71,20 @@ func (h APIHandler) RegisterRoutes() {
 	auth.GET("/sso", h.ssoRedirecter)
 	auth.POST("/sso/saml", h.samlConnecter)
 
+	empty := h.Server.Group("/")
+	empty.GET("/placeholder", func(c *gin.Context) {
+		c.JSON(200, response(200, "", []string{"Please come again!"}))
+	})
+	empty.POST("/placeholder", func(c *gin.Context) {
+		var data any
+		err := c.BindJSON(&data)
+		if err != nil {
+			c.AbortWithError(http.StatusNotAcceptable, err)
+			return
+		}
+		c.JSON(200, response(200, "", []any{data}))
+	})
+
 	routes := h.Server.Group("/api/v1/")
 	routes.Use(validateJwt)
 	routes.GET("/", h.Index)
@@ -100,18 +115,17 @@ func (h APIHandler) RegisterRoutes() {
 	routes.GET("/resource/:tfo_resource_uuid/generations", h.GetDistinctGeneration)
 	// ReourceSpec
 	routes.GET("/resource/:tfo_resource_uuid/resource-spec/generation/:generation", h.GetResourceSpec)
-	// // Poll for resource objects in the cluster
-	// routes.GET("/resource/:tfo_resource_uuid/poll", h.ResourcePoll)
-	// Logs
-	routes.POST("/logs", h.AddTFOTaskLogs) // requires access to fs of logs
+
 	routes.GET("/resource/:tfo_resource_uuid/logs", h.GetClustersResourcesLogs)
 	routes.GET("/resource/:tfo_resource_uuid/logs/generation/:generation", h.GetClustersResourcesLogs)
 	routes.GET("/resource/:tfo_resource_uuid/logs/generation/:generation/task/:task_type", h.GetClustersResourcesLogs)
 	routes.GET("/resource/:tfo_resource_uuid/logs/generation/:generation/task/:task_type/rerun/:rerun", h.GetClustersResourcesLogs)
 	routes.GET("/task/:task_pod_uuid/logs", h.GetTFOTaskLogsViaTask)
+
 	// Tasks
-	routes.POST("/task", h.AddTaskPod) // requires access to fs of logs
-	routes.GET("/task/:task_pod_uuid", h.GetTaskPod)
+	routes.POST("/task", h.AddTaskPod)
+	routes.GET("/task/:task_pod_uuid", h.GetTaskPod) // TODO Should getting a task out of band (ie not with cluster info) be allowed?
+
 	// Approval
 	routes.GET("/resource/:tfo_resource_uuid/approval-status", h.GetApprovalStatus)
 	routes.GET("/task/:task_pod_uuid/approval-status", h.GetApprovalStatusViaTaskPodUUID)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,6 +18,7 @@ type APIHandler struct {
 	Queue     *deque.Deque[tfv1beta1.Terraform]
 	clientset kubernetes.Interface
 	ssoConfig *SSOConfig
+	serviceIP *string
 	tenant    string
 }
 
@@ -53,7 +54,7 @@ func NewSAMLConfig(issuer, recipient, metadataURL string) (*SSOConfig, error) {
 	}, nil
 }
 
-func NewAPIHandler(db *gorm.DB, queue *deque.Deque[tfv1beta1.Terraform], clientset kubernetes.Interface, ssoConfig *SSOConfig) *APIHandler {
+func NewAPIHandler(db *gorm.DB, queue *deque.Deque[tfv1beta1.Terraform], clientset kubernetes.Interface, ssoConfig *SSOConfig, serviceIP *string) *APIHandler {
 
 	return &APIHandler{
 		Server:    gin.Default(),
@@ -61,6 +62,7 @@ func NewAPIHandler(db *gorm.DB, queue *deque.Deque[tfv1beta1.Terraform], clients
 		Queue:     queue,
 		clientset: clientset,
 		ssoConfig: ssoConfig,
+		serviceIP: serviceIP,
 	}
 }
 
@@ -125,7 +127,7 @@ func (h APIHandler) RegisterRoutes() {
 	// Tasks via task JWT
 	authenticatedTask := h.Server.Group("/api/v1/task")
 	authenticatedTask.Use(validateTaskJWT)
-	authenticatedTask.POST("/", h.AddTaskPod)
+	authenticatedTask.POST("", h.AddTaskPod)
 
 	// Approval
 	authenticatedAPIV1.GET("/resource/:tfo_resource_uuid/approval-status", h.GetApprovalStatus)

--- a/pkg/api/get_record.go
+++ b/pkg/api/get_record.go
@@ -275,7 +275,7 @@ func (h APIHandler) ResourceLogs(generationFilter, rerunFilter, taskTypeFilter, 
 		taskPodUUIDs = append(taskPodUUIDs, t.UUID)
 	}
 	var tfoTaskLogs []models.TFOTaskLog
-	if result := h.DB.Where("tfo_resource_uuid = ? AND task_pod_uuid IN ?", &uuid, taskPodUUIDs).Find(&tfoTaskLogs); result.Error != nil {
+	if result := h.DB.Where("task_pod_uuid IN ?", taskPodUUIDs).Find(&tfoTaskLogs); result.Error != nil {
 		return logs, result.Error
 	}
 
@@ -284,13 +284,12 @@ func (h APIHandler) ResourceLogs(generationFilter, rerunFilter, taskTypeFilter, 
 	for _, taskPod := range taskPodsOfHighestRerun {
 		for _, log := range tfoTaskLogs {
 			if log.TaskPodUUID == taskPod.UUID {
+				// TODO does the size need to be sent?
 				logs = append(logs, ResourceLog{
-					ID:              log.ID,
-					LogMessage:      log.Message,
-					LineNo:          log.LineNo,
-					Rerun:           taskPod.Rerun,
-					TaskType:        taskPod.TaskType,
-					TFOResourceUUID: log.TFOResourceUUID,
+					ID:         log.ID,
+					LogMessage: log.Message,
+					Rerun:      taskPod.Rerun,
+					TaskType:   taskPod.TaskType,
 				})
 			}
 		}

--- a/pkg/api/log.go
+++ b/pkg/api/log.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/galleybytes/terraform-operator-api/pkg/common/models"
 	"github.com/gin-gonic/gin"
@@ -11,7 +13,12 @@ import (
 func (h APIHandler) AddTaskPod(c *gin.Context) {
 
 	jsonData := struct {
-		TaskPod models.TaskPod `json:"task_pod"`
+		TFOResourceUUID string `json:"tfo_resource_uuid"`
+		Generation      string `json:"tfo_resource_generation"`
+		RerunID         string `json:"rerun_id"`
+		TaskName        string `json:"task_name"`
+		UUID            string `json:"uuid"`
+		Content         string `json:"content"`
 	}{}
 	err := c.BindJSON(&jsonData)
 	if err != nil {
@@ -19,19 +26,71 @@ func (h APIHandler) AddTaskPod(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
 		return
 	}
-	if jsonData.TaskPod.UUID == "" {
+	if jsonData.UUID == "" {
 		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, "missing request data", nil))
 		return
 	}
 
-	taskPod := jsonData.TaskPod
-	result := h.DB.Where("uuid = ?", &taskPod.UUID).FirstOrCreate(&taskPod)
+	rerunID, err := strconv.Atoi(jsonData.RerunID)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, fmt.Sprintf("rerun is must be an int, got %s", jsonData.RerunID), nil))
+		return
+	}
+
+	taskPod := models.TaskPod{
+		UUID:            jsonData.UUID,
+		TaskType:        jsonData.TaskName,
+		Generation:      jsonData.Generation,
+		Rerun:           rerunID,
+		TFOResourceUUID: jsonData.TFOResourceUUID,
+	}
+	result := h.DB.Where("uuid = ?", &jsonData.UUID).FirstOrCreate(&taskPod)
 	if result.Error != nil {
 		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, result.Error.Error(), nil))
 		return
 	}
 
-	c.JSON(http.StatusOK, response(http.StatusOK, "", []models.TaskPod{taskPod}))
+	if jsonData.Content == "" {
+		c.JSON(http.StatusOK, response(http.StatusOK, "", []models.TaskPod{taskPod}))
+	}
+
+	// Combine the creation or finding of the taskPod with logging when content is sent
+	err = h.saveTaskLog(taskPod.UUID, jsonData.Content)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+
+}
+
+func (h APIHandler) saveTaskLog(taskUUID, content string) error {
+
+	taskLog := models.TFOTaskLog{
+		TaskPodUUID: taskUUID,
+		Message:     content,
+		Size:        uint64(len([]byte(content))),
+	}
+
+	if result := h.DB.Where("task_pod_uuid = ?", &taskLog.TaskPodUUID).FirstOrCreate(&taskLog); result.Error != nil {
+		return fmt.Errorf("failed to save task log: %+v, %+v", taskLog, result.Error)
+	}
+
+	if taskLog.Size != uint64(len([]byte(content))) {
+		if taskLog.Size > uint64(len([]byte(content))) {
+			return fmt.Errorf("The message size was smaller than already recorded")
+		}
+		// The content has been updated. Read the bytes after what has already been written to preserve the
+		// original content. We don't want to allow logs in the database to be changed once they are written.
+		taskLog.Message += string([]byte(content)[taskLog.Size:])
+		taskLog.Size = uint64(len([]byte(taskLog.Message)))
+		if result := h.DB.Save(&taskLog); result.Error != nil {
+			return result.Error
+		}
+	}
+
+	return nil
 }
 
 func (h APIHandler) AddTFOTaskLogs(c *gin.Context) {

--- a/pkg/api/log.go
+++ b/pkg/api/log.go
@@ -61,9 +61,10 @@ func (h APIHandler) AddTaskPod(c *gin.Context) {
 
 	if jsonData.Content == "" {
 		c.JSON(http.StatusOK, response(http.StatusOK, "", []models.TaskPod{taskPod}))
+		return
 	}
 
-	// Combine the creation or finding of the taskPod with logging when content is sent
+	// Task calls will generally contain content. Save the message to the database.
 	err = saveTaskLog(h.DB, taskPod.UUID, jsonData.Content)
 	if err != nil {
 		c.JSON(http.StatusUnprocessableEntity, response(http.StatusUnprocessableEntity, err.Error(), nil))
@@ -74,6 +75,7 @@ func (h APIHandler) AddTaskPod(c *gin.Context) {
 
 }
 
+// Write or update logs in database
 func saveTaskLog(db *gorm.DB, taskUUID, content string) error {
 
 	taskLog := models.TFOTaskLog{

--- a/pkg/common/models/tfo.go
+++ b/pkg/common/models/tfo.go
@@ -8,12 +8,10 @@ import (
 
 type TFOTaskLog struct {
 	gorm.Model
-	TaskPod         TaskPod     `json:"task_pod,omitempty"`
-	TaskPodUUID     string      `json:"task_pod_uuid"`
-	TFOResource     TFOResource `json:"tfo_resource,omitempty"`
-	TFOResourceUUID string      `json:"tfo_resource_uuid"`
-	Message         string      `json:"message"`
-	LineNo          string      `json:"line_no"`
+	TaskPod     TaskPod `json:"task_pod,omitempty"`
+	TaskPodUUID string  `json:"task_pod_uuid"`
+	Message     string  `json:"message" gorm:"type:varchar(1048576)"`
+	Size        uint64  `json:"size"`
 }
 
 type TFOResource struct {


### PR DESCRIPTION
the TFO_ORIGIN environment variables are used to tie the original resource that is sent from external agents thru the API to get added to the vCluster. This allows the usage the the UUID to match what will exist in the TFO API's database.

**BREAKING CHANGES**
there are changes to the database for the `tfo_task_log` and the `task_pod` models that are no longer compatible with previous versions. The old tables might need to be dropped manually if gorm autoMigrate doesn't pick up the changes. Since TFO API make incompatible changes with logs around v`4.0.0`, this shouldn't affect anyone and dropping tables should be safe. _I've only tested this on a tiny little test setup_