### PR TITLE
add automatic fswatch as sidecar

### DIFF
--- a/pkg/api/log.go
+++ b/pkg/api/log.go
@@ -92,7 +92,7 @@ func saveTaskLog(db *gorm.DB, taskUUID, content string) error {
 
 	if taskLog.Size != uint64(len([]byte(content))) {
 		if taskLog.Size > uint64(len([]byte(content))) {
-			return fmt.Errorf("sent log's size was smaller than previously version")
+			return fmt.Errorf("sent log's size was smaller than earlier recorded log")
 		}
 		// The content has been updated. Read the bytes after what has already been written to preserve the
 		// original content. We don't want to allow logs in the database to be changed once they are written.


### PR DESCRIPTION
fswatch checks the fs for changes to "logs" and records them to the api db

- changes the terraform patch api call to a terraform update api call when updating resources. Update minimizes drift by applying what is defined in its entirety instead of trying to merge via patching strategies. 