### PR TITLE
Change the tf/task jwt token management

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ var (
 	useServiceHost  bool
 	serviceName     string
 	dashboard       string
+	fswatchImage    string
 )
 
 func main() {
@@ -60,6 +61,8 @@ func main() {
 	viper.BindPFlag("service-name", pflag.Lookup("service-name"))
 	pflag.StringVar(&dashboard, "dashboard", "", "Connect to the dashboard with api credentials")
 	viper.BindPFlag("dashboard", pflag.Lookup("dashboard"))
+	pflag.StringVar(&fswatchImage, "fswatch-image", "ghcr.io/galleybytes/fswatch:0.11.0", "Docker image for fswatch (log-service)")
+	viper.BindPFlag("fswatch-image", pflag.Lookup("fswatch-image"))
 	pflag.Parse()
 
 	pflag.Set("alsologtostderr", "false")
@@ -80,6 +83,7 @@ func main() {
 	useServiceHost = viper.GetBool("use-service-host")
 	serviceName = viper.GetString("service-name")
 	dashboard = viper.GetString("dashboard")
+	fswatchImage = viper.GetString("fswatch-image")
 
 	clientset := kubernetes.NewForConfigOrDie(NewConfigOrDie(os.Getenv("KUBECONFIG")))
 	var database *gorm.DB
@@ -109,7 +113,7 @@ func main() {
 		}
 	}
 
-	apiHandler := api.NewAPIHandler(database, clientset, ssoConfig, &serviceIP, &dashboard)
+	apiHandler := api.NewAPIHandler(database, clientset, ssoConfig, &serviceIP, &dashboard, fswatchImage)
 	apiHandler.RegisterRoutes()
 	fmt.Printf("Starting server on %s\n", addr)
 	apiHandler.Server.Run(addr)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -85,6 +85,7 @@ func (h APIHandler) RegisterRoutes() {
 	})
 
 	preauth.POST("/login", h.login)
+	preauth.POST("/refresh", h.loginWithRefreshToken)
 	preauth.GET("/connect", h.defaultConnectMethod) // Determine preferred auth method
 	preauth.GET("/sso", h.ssoRedirecter)
 	preauth.POST("/sso/saml", h.samlConnecter)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -13,14 +13,15 @@ import (
 )
 
 type APIHandler struct {
-	Server    *gin.Engine
-	DB        *gorm.DB
-	clientset kubernetes.Interface
-	ssoConfig *SSOConfig
-	serviceIP *string
-	tenant    string
-	Cache     *cache.Cache
-	dashboard *string
+	Server       *gin.Engine
+	DB           *gorm.DB
+	clientset    kubernetes.Interface
+	ssoConfig    *SSOConfig
+	serviceIP    *string
+	tenant       string
+	Cache        *cache.Cache
+	dashboard    *string
+	fswatchImage string
 }
 
 type SSOConfig struct {
@@ -55,16 +56,17 @@ func NewSAMLConfig(issuer, recipient, metadataURL string) (*SSOConfig, error) {
 	}, nil
 }
 
-func NewAPIHandler(db *gorm.DB, clientset kubernetes.Interface, ssoConfig *SSOConfig, serviceIP, dashboard *string) *APIHandler {
+func NewAPIHandler(db *gorm.DB, clientset kubernetes.Interface, ssoConfig *SSOConfig, serviceIP, dashboard *string, fswatchImage string) *APIHandler {
 
 	return &APIHandler{
-		Server:    gin.Default(),
-		DB:        db,
-		clientset: clientset,
-		ssoConfig: ssoConfig,
-		serviceIP: serviceIP,
-		Cache:     cache.New(20 * time.Second),
-		dashboard: dashboard,
+		Server:       gin.Default(),
+		DB:           db,
+		clientset:    clientset,
+		ssoConfig:    ssoConfig,
+		serviceIP:    serviceIP,
+		Cache:        cache.New(20 * time.Second),
+		dashboard:    dashboard,
+		fswatchImage: fswatchImage,
 	}
 }
 

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -1412,7 +1412,7 @@ func (h APIHandler) addResource(c *gin.Context) (string, error) {
 	appendClusterNameLabel(&jsonData.Terraform, cluster.Name)
 	addGlobalTaskOptions(&jsonData.Terraform, h.tenant, clusterName, apiURL)
 
-	err = applyOnCreateOrUpdate(c, jsonData.Terraform, h.clientset, h.tenant)
+	err = applyOnCreateOrUpdate(c, jsonData.Terraform, h.clientset, h.tenant, h.fswatchImage)
 	if err != nil {
 		return "", err
 	}
@@ -1508,7 +1508,7 @@ func (h APIHandler) updateResource(c *gin.Context) error {
 	appendClusterNameLabel(&jsonData.Terraform, clusterName)
 	addGlobalTaskOptions(&jsonData.Terraform, h.tenant, clusterName, apiURL)
 
-	err = applyOnCreateOrUpdate(c, jsonData.Terraform, h.clientset, h.tenant)
+	err = applyOnCreateOrUpdate(c, jsonData.Terraform, h.clientset, h.tenant, h.fswatchImage)
 	if err != nil {
 		return err
 	}
@@ -1868,7 +1868,7 @@ func jsonify(o interface{}) (string, error) {
 	return string(b), nil
 }
 
-func applyOnCreateOrUpdate(ctx context.Context, tf tfv1beta1.Terraform, clientset kubernetes.Interface, _tenantID string) error {
+func applyOnCreateOrUpdate(ctx context.Context, tf tfv1beta1.Terraform, clientset kubernetes.Interface, _tenantID, fswatchImage string) error {
 	// tenantID is totally broken right now. Just hardcode this for now
 	tenantID := "internal"
 
@@ -1935,7 +1935,7 @@ func applyOnCreateOrUpdate(ctx context.Context, tf tfv1beta1.Terraform, clientse
 	}
 
 	fswatchImageConfig := tfv1beta1.ImageConfig{
-		Image:           "ghcr.io/galleybytes/fswatch:0.10.2",
+		Image:           fswatchImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 	for _, taskName := range []tfv1beta1.TaskName{

--- a/pkg/common/db/db.go
+++ b/pkg/common/db/db.go
@@ -21,6 +21,7 @@ func Init(url string) *gorm.DB {
 		&models.TFOResourceSpec{},
 		&models.Approval{},
 		&models.TaskPod{},
+		&models.RefreshToken{},
 	)
 
 	if err != nil {

--- a/pkg/common/models/tfo.go
+++ b/pkg/common/models/tfo.go
@@ -67,6 +67,19 @@ type Approval struct {
 
 type ResourceState string
 
+type RefreshToken struct {
+	gorm.Model
+	RefreshToken   string
+	Version        int
+	UsedAt         *time.Time
+	ReUsedAt       *time.Time
+	CanceledAt     *time.Time
+	CanceledReason string
+
+	TFOResourceSpec   TFOResourceSpec `json:"tfo_resource_spec,omitempty"`
+	TFOResourceSpecID uint            `json:"tfo_resource_spec_id"`
+}
+
 const (
 	Untracked ResourceState = "untracked"
 	Running   ResourceState = "running"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"reflect"
 	"strings"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 func Tmpdir() string {
@@ -41,4 +43,14 @@ func Trunc(s string, n uint) string {
 func B64Encode(input string) string {
 	encoded := base64.StdEncoding.EncodeToString([]byte(input))
 	return encoded
+}
+
+func HashPassword(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
+	return string(bytes), err
+}
+
+func CheckPasswordHash(password, hash string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"encoding/base64"
 	"os"
 	"reflect"
+	"strings"
 )
 
 func Tmpdir() string {
@@ -22,4 +24,21 @@ func Contains[T any](things []T, thing T) bool {
 		}
 	}
 	return false
+}
+
+// Truncate an already valid resource name
+// With valid resource names, it is safe to assume only contains dashes (dots?)
+func Trunc(s string, n uint) string {
+	if len(s) > int(n) {
+		s = s[:n]
+		// TODO fix naive approach of sanitizing
+		s = strings.TrimRight(s, "-")
+		s = strings.TrimRight(s, ".")
+	}
+	return s
+}
+
+func B64Encode(input string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(input))
+	return encoded
 }


### PR DESCRIPTION
Writes jwt tokens to a secret and sourced into a task. JWTs now come with single use refresh token. A new login endpoint is used to refresh tokens @ `/refresh`